### PR TITLE
Match placeholders in the replacement string with matched subgroups.

### DIFF
--- a/goreplace.go
+++ b/goreplace.go
@@ -17,6 +17,7 @@ const (
 	Author  = "Alexander Solovyov"
 	Version = "1.8"
 )
+
 var byteNewLine = []byte("\n")
 
 var opts struct {
@@ -33,7 +34,7 @@ var opts struct {
 	Verbose         bool     `short:"v" long:"verbose" description:"be verbose (show non-fatal errors, like unreadable files)"`
 	ShowVersion     bool     `short:"V" long:"version" description:"show version and exit"`
 	ShowHelp        bool     `long:"help" description:"show this help message"`
-	NoColors		bool	 `short:"c" long:"no-colors" description:"do not show colors in output"`
+	NoColors        bool     `short:"c" long:"no-colors" description:"do not show colors in output"`
 }
 
 func main() {
@@ -119,7 +120,7 @@ type GRVisitor struct {
 	acceptedFileMatcher Matcher
 	// errors              chan error
 	// Used to prevent sparse newline at the end of output
-	prependNewLine      bool
+	prependNewLine bool
 }
 
 func (v *GRVisitor) Walk(fn string, fi os.FileInfo, err error) error {
@@ -263,10 +264,10 @@ func (v *GRVisitor) SearchFile(fn string, content []byte) {
 				fmt.Printf("Binary file '%s' matches", fn)
 				break
 			} else {
-				if (!opts.NoColors) {
+				if !opts.NoColors {
 					color.Printf("@g%s\n", fn)
 				} else {
-					fmt.Printf("%s\n",fn)
+					fmt.Printf("%s\n", fn)
 				}
 			}
 		}
@@ -275,15 +276,15 @@ func (v *GRVisitor) SearchFile(fn string, content []byte) {
 			return
 		}
 
-		if (!opts.NoColors) {
+		if !opts.NoColors {
 			color.Printf("@!@y%d:", info.num)
 		} else {
 			fmt.Printf("%d:", info.num)
 		}
 		colored := v.pattern.ReplaceAllStringFunc(string(info.line),
 			func(wrap string) string {
-				var res string				
-				if (!opts.NoColors) {
+				var res string
+				if !opts.NoColors {
 					res = color.Sprintf("@Y%s", wrap)
 				} else {
 					res = fmt.Sprintf("%s", wrap)
@@ -305,7 +306,7 @@ func (v *GRVisitor) SearchFileName(fn string) {
 	colored := v.pattern.ReplaceAllStringFunc(fn,
 		func(wrap string) string {
 			var res string
-			if (!opts.NoColors) {
+			if !opts.NoColors {
 				res = color.Sprintf("@Y%s", wrap)
 			} else {
 				res = fmt.Sprintf("%s", wrap)
@@ -349,7 +350,7 @@ func (v *GRVisitor) ReplaceInFile(fn string, content []byte) (changed bool, resu
 		}
 		if !changed {
 			changed = true
-			if (!opts.NoColors) {
+			if !opts.NoColors {
 				color.Printf("@g%s", fn)
 			} else {
 				fmt.Printf("%s", fn)
@@ -357,11 +358,11 @@ func (v *GRVisitor) ReplaceInFile(fn string, content []byte) (changed bool, resu
 		}
 
 		changenum += 1
-		return []byte(*opts.Replace)
+		return v.pattern.ReplaceAll(s, []byte(*opts.Replace))
 	})
 
 	if changenum > 0 {
-		if (!opts.NoColors) {
+		if !opts.NoColors {
 			color.Printf("@!@y - %d change%s made\n",
 				changenum, getSuffix(changenum))
 		} else {


### PR DESCRIPTION
`goreplace '(Happy) (Christmas|Xmas)' -r '$1 ☃☃ $2 ☃☃'`

So `Happy Christmas` turns into `Happy ☃☃ Christmas ☃☃`.

(There's a bunch of changes made by `go fmt`, I hope you don't care.)
