### PR TITLE
Add `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/piranha/goreplace
+
+go 1.14
+
+require (
+	github.com/jessevdk/go-flags v1.4.0
+	github.com/pyk/byten v0.0.0-20140925233358-f847a130bf6d
+	github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/pyk/byten v0.0.0-20140925233358-f847a130bf6d h1:/0nqYrqVyPTVDT2jPx9z9BZ+ItJWlWA9VITUGvNaZkI=
+github.com/pyk/byten v0.0.0-20140925233358-f847a130bf6d/go.mod h1:El8LdwAxb76Ih0mRmpu9uMVq+ajiqGSxmYiUe+nSr+w=
+github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=
+github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=

--- a/tests/main.t
+++ b/tests/main.t
@@ -1,8 +1,7 @@
 Go Replace tests:
 
-  $ go build -o gr goreplace 2> /dev/null || go build -o gr github.com/piranha/goreplace
-  $ CURRENT=$(pwd)
-  $ alias gr="$CURRENT/gr -c"
+  $ START_DIR=$PWD && cd $TESTDIR && cd ./.. && go build -o $START_DIR/gr && cd $START_DIR
+  $ alias gr="$START_DIR/gr -c"
 
 Usage:
 


### PR DESCRIPTION
Hi, great tool, thanks!

This doesn't do anything new, just adds the Go module files.

I'm not sure if this is particularly an improvement aside from pinning versions of the dependencies and enabling Github Dependabot to analyse the project, but it makes it easier for me to package the app using Nix, which is why I have a fork (Nix expression below, in case anyone is looking).

```nix
{ lib, buildGoModule, fetchFromGitHub }:

buildGoModule rec {
  pname = "goreplace";
  version = "2.6";

  src = fetchFromGitHub {
    owner = "a-h";
    repo = "goreplace";
    rev = "653683efc0a6e08da1168c6599216ee81236f95b";
    sha256 = "1ia0yns20q8b9yhmpyavzbb2zvyh960i5v1hbprsb3pqb76h89cg";
  };

  vendorSha256 = "0njcdk1yns5jp9zklpw63r6xvdlz96l1ba66hhngczr3017g66jf";

  meta = with lib; {
    description = "Replace in files.";
    homepage = https://github.com/piranha/goreplace;
    license = licenses.isc;
    maintainers = with maintainers; [ piranha ];
    platforms = platforms.linux ++ platforms.darwin;
  };
}
```